### PR TITLE
Add ability to update profile info

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,9 @@ AllCops:
     - vendor/**/*
     - tmp/**/*
 
+I18n/GetText/DecorateFunctionMessage:
+  Enabled: false
+
 I18n/GetText/DecorateString:
   Exclude:
     - spec/**/*.rb

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,5 +2,7 @@ class ApplicationController < ActionController::Base
   include Authentication
   include Authorization
 
+  before_action :authorize_resource!
+
   expose :decorated_user, -> { UserDecorator.new(current_user) }
 end

--- a/app/controllers/blog_controller.rb
+++ b/app/controllers/blog_controller.rb
@@ -1,5 +1,5 @@
 class BlogController < ApplicationController
-  before_action :authenticate_current_user!, only: %i[]
+  skip_before_action :authorize_resource!
   skip_after_action :verify_authorized, only: %i[index]
 
   def index; end

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -11,7 +11,7 @@ module Authentication
   def authenticate_current_user!
     return if session[:current_user_id] && current_user.present?
 
-    raise UserNotAuthenticated(_("No currrent_user_id in session"))
+    raise UserNotAuthenticated, "No current_user_id in session"
   end
 
   def current_user

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,5 @@
 class SessionsController < ApplicationController
+  skip_before_action :authorize_resource!
   skip_after_action :verify_authorized
 
   def new
@@ -6,8 +7,6 @@ class SessionsController < ApplicationController
   end
 
   def create
-    authenticated_user = authenticate_user
-
     if authenticated_user
       session[:current_user_id] = authenticated_user.id
       redirect_to root_path, notice: I18n.t("authentication.sign_in.success")
@@ -28,7 +27,7 @@ class SessionsController < ApplicationController
     params.require(:user).permit(:email, :password)
   end
 
-  def authenticate_user
-    User.find_by(email: user_params[:email])&.authenticate(user_params[:password])
+  def authenticated_user
+    @authenticated_user ||= User.find_by(email: user_params[:email])&.authenticate(user_params[:password])
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,4 @@
 class UsersController < ApplicationController
-  skip_after_action :verify_authorized, only: %i[new create]
-  before_action -> { authorize User }, only: %i[show edit update]
-
   expose :user
 
   def show; end
@@ -28,6 +25,10 @@ class UsersController < ApplicationController
   end
 
   private
+
+  def authorize_resource!
+    authorize User
+  end
 
   def user_params
     params.require(:user).permit(:first_name, :last_name, :email, :password)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,13 +1,10 @@
 class UsersController < ApplicationController
   skip_after_action :verify_authorized, only: %i[new create]
+  before_action -> { authorize User }, only: %i[show edit update]
 
   expose :user
 
-  def show
-    self.user = current_user
-
-    authorize User
-  end
+  def show; end
 
   def new; end
 
@@ -17,6 +14,16 @@ class UsersController < ApplicationController
       redirect_to root_path, notice: I18n.t("authentication.sign_up.success")
     else
       render :new
+    end
+  end
+
+  def edit; end
+
+  def update
+    if current_user.update(user_params)
+      redirect_to user_path
+    else
+      render :edit
     end
   end
 

--- a/app/policies/blog_policy.rb
+++ b/app/policies/blog_policy.rb
@@ -1,13 +1,13 @@
 class BlogPolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+
   class Scope < Scope
-    def index?
-      true
-    end
-
-    def show?
-      true
-    end
-
     def resolve
       scope.all
     end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,4 +1,12 @@
 class UserPolicy < ApplicationPolicy
+  def new?
+    true
+  end
+
+  def create?
+    true
+  end
+
   def show?
     user.present?
   end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -3,6 +3,10 @@ class UserPolicy < ApplicationPolicy
     user.present?
   end
 
+  def update?
+    user.present?
+  end
+
   class Scope < Scope
     def resolve
       scope.all

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -4,4 +4,4 @@
   = form.input :email
   = form.input :password, required: true
 
-  = form.submit "Sign Up", class: "btn btn-primary"
+  = form.submit "#{user.new_record? ? "Sign Up" : "Update"}", class: "btn btn-primary"

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -4,4 +4,4 @@
   = form.input :email
   = form.input :password, required: true
 
-  = form.submit "#{user.new_record? ? "Sign Up" : "Update"}", class: "btn btn-primary"
+  = form.submit "#{user.new_record? ? 'Sign Up' : 'Update'}", class: "btn btn-primary"

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -1,0 +1,3 @@
+h1 Edit profile
+
+= render "form", user: current_user

--- a/app/views/users/new.html.slim
+++ b/app/views/users/new.html.slim
@@ -1,3 +1,3 @@
 h1 Sign Up
 
-= render "form", user: user
+= render "form"

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,13 +1,16 @@
 h1 Your Profile
-- if current_user.first_name.present?
-    p
-      strong First name:
-      |  #{current_user.first_name}
+p
+  strong First name:
+  |  #{current_user.first_name}
+
 - if current_user.last_name.present?
-    p
-      strong Last name:
-      |  #{current_user.last_name}
+  p
+    strong Last name:
+    |  #{current_user.last_name}
 
 p
   strong Email:
   |  #{current_user.email}
+
+p
+  = link_to "Edit profile", edit_user_path, class: "btn btn-secondary"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   root to: "blog#index"
 
   resource :blog, only: %i[index]
-  resource :user, only: %i[new create show]
+  resource :user, only: %i[new create show edit update]
   resource :session, only: %i[new create destroy]
 
   resolve("User") { %i[user] }

--- a/spec/features/user/update_spec.rb
+++ b/spec/features/user/update_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.feature "Update profile" do
+  include_context "when user signed in"
+
+  before do
+    visit edit_user_path
+  end
+
+  scenario "User updates profile with valid data" do
+    fill_form(:user, :edit, last_name: "Khusaenov")
+    click_on "Update"
+
+    expect(page).to have_content("Last name: Khusaenov")
+  end
+end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -8,12 +8,13 @@ RSpec.describe UserPolicy do
   context "when user isn't present" do
     let(:user) { nil }
 
-    it { is_expected.not_to permit_action(:show) }
+    it { is_expected.to permit_actions(%i[new create]) }
+    it { is_expected.to forbid_actions(%i[show update]) }
   end
 
   context "when user is present" do
     let(:user) { create(:user) }
 
-    it { is_expected.to permit_action(:show) }
+    it { is_expected.to permit_actions(%i[new create show update]) }
   end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Users", type: :request do
   let(:valid_attributes) { { first_name: "Rasim", email: "rasim.khusaenov@flatstack.dev", password: "101" } }
-  let(:invalid_attributes) { { first_name: "Rasim", password: "101" } }
+  let(:invalid_attributes) { { first_name: "Rasim", email: "", password: "101" } }
 
   describe "GET /new" do
     it "renders a successful response" do
@@ -46,8 +46,47 @@ RSpec.describe "Users", type: :request do
     end
 
     it "renders a user email" do
-      user = User.last
-      expect(user.email).to eq(valid_attributes[:email])
+      expect(response.body).to include(valid_attributes[:email])
+    end
+  end
+
+  describe "GET /edit" do
+    it "render a successful response" do
+      post user_path, params: { user: valid_attributes }
+      get edit_user_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe "PATCH /update" do
+    before do
+      post user_path, params: { user: valid_attributes }
+    end
+
+    context "with valid parameters" do
+      let(:new_attributes) { { last_name: "Khusaenov" } }
+
+      before do
+        patch user_path, params: { user: new_attributes }
+      end
+
+      it "updates the user" do
+        expect(User.last.last_name).to eq("Khusaenov")
+      end
+
+      it "redirects to the user profile" do
+        expect(response).to redirect_to(user_path)
+      end
+    end
+
+    context "with invalid parameters" do
+      before do
+        patch user_path, params: { user: invalid_attributes }
+      end
+
+      it "renders a successful response (i.e. to display the 'edit' template)" do
+        expect(response).to be_successful
+      end
     end
   end
 end


### PR DESCRIPTION
### Summary

Add ability to update profile info -- first and last names, email, password -- without password confirmation ('cause of #5 issue).

### How it works

![image](https://user-images.githubusercontent.com/35406008/162589899-5bf80909-147c-447b-bde3-285f1b4a2b65.png)
![image](https://user-images.githubusercontent.com/35406008/162589919-7b18a38a-4c10-4212-9a0e-b4545872f2b3.png)
![image](https://user-images.githubusercontent.com/35406008/162589933-6f95f942-b618-4d81-9a3f-c69b4682ad9d.png)

### Test plan

List of steps to manually test introduced functionality:

- Log in
- Go to http://localhost:3000/user/edit
- Edit fields
- Click `Update`
- You are awesome!

### Deploy notes

N/A

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests for new functionality
- [x] My pull request is shorter than 500 lines

### References
- Resolves #9 Issue
